### PR TITLE
Fix typo in the CLI program options (--typeAssertions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ pragmatist build --notifications
 
 ### Types
 
-Use `--type-assertions` flag to enable [runtime type assertions](https://github.com/codemix/babel-plugin-typecheck).
+Use `--typeAssertions` flag to enable [runtime type assertions](https://github.com/codemix/babel-plugin-typecheck).
 
 ```sh
-pragmatist build --type-assertions
+pragmatist build --typeAssertions
 ```
 
 ## NPM


### PR DESCRIPTION
Although I am not sure if it should be `--type-assertions` instead (that's how most (all?) CLIs have 'em), but the docs are not in sync with the usage. Latest pragmatist (3.0.2) accepts `--typeAssertions` and complains otherwise.
