### PR TITLE
Fix linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "create-index": "create-index ./src --update-index",
     "format-json": "jsonlint --sort-keys --in-place --indent '    '",
     "format-json-config": "npm run format-json ./package.json; npm run format-json ./src/babelrc.json",
-    "lint": "canonical ./src/",
+    "lint": "canonical lint ./src/",
     "watch-build": "npm run build; babel --watch ./src --out-dir ./dist --source-maps"
   },
   "version": "3.0.14"


### PR DESCRIPTION
Still getting these errors btw, but linting seems working again. 

```
$ npm run lint

> pragmatist@3.0.13 lint /Users/tieme/pragmatist
> canonical lint ./src/

Error Unknown argument: ./src/
Error Unknown argument: ./src/
The react/jsx-sort-prop-types rule is deprecated. Please use the react/sort-prop-types rule instead.
/Users/tieme/pragmatist/src/bin/index.js

║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║
...
```
